### PR TITLE
Reversed implementations for camelCase and PascalCase

### DIFF
--- a/lib/accent/transformers/camel_case.ex
+++ b/lib/accent/transformers/camel_case.ex
@@ -1,6 +1,6 @@
 defmodule Accent.Transformer.CamelCase do
   @moduledoc """
-  Converts the given binary or atom to CamelCase format.
+  Converts the given binary or atom to camelCase format.
   """
 
   @behaviour Accent.Transformer
@@ -14,7 +14,7 @@ defmodule Accent.Transformer.CamelCase do
   def call(""), do: ""
 
   def call(<<h::utf8, t::binary>>) do
-    String.upcase(<<h>>) <> do_camelize(t)
+    String.downcase(<<h>>) <> do_camelize(t)
   end
 
   # private

--- a/lib/accent/transformers/pascal_case.ex
+++ b/lib/accent/transformers/pascal_case.ex
@@ -1,6 +1,6 @@
 defmodule Accent.Transformer.PascalCase do
   @moduledoc """
-  Converts the given binary or atom to pascalCase format.
+  Converts the given binary or atom to PascalCase format.
   """
 
   @behaviour Accent.Transformer
@@ -14,7 +14,7 @@ defmodule Accent.Transformer.PascalCase do
   def call(""), do: ""
 
   def call(<<h::utf8, t::binary>>) do
-    String.downcase(<<h>>) <> do_pascalize(t)
+    String.upcase(<<h>>) <> do_pascalize(t)
   end
 
   # private

--- a/test/accent/plugs/request_test.exs
+++ b/test/accent/plugs/request_test.exs
@@ -31,7 +31,7 @@ defmodule Accent.Plug.RequestTest do
           Accent.Plug.Request.init(transformer: Accent.Transformer.CamelCase)
         )
 
-      assert conn.params == %{"HelloWorld" => "value"}
+      assert conn.params == %{"helloWorld" => "value"}
     end
 
     test "properly handles POST requests" do

--- a/test/accent/plugs/response_test.exs
+++ b/test/accent/plugs/response_test.exs
@@ -75,7 +75,7 @@ defmodule Accent.Plug.ResponseTest do
         |> Accent.Plug.Response.call(@opts)
         |> Plug.Conn.send_resp(200, "{\"hello_world\":\"value\"}")
 
-      assert conn.resp_body == "{\"helloWorld\":\"value\"}"
+      assert conn.resp_body == "{\"HelloWorld\":\"value\"}"
     end
 
     test "deals with content-type having a charset" do
@@ -87,7 +87,7 @@ defmodule Accent.Plug.ResponseTest do
         |> Accent.Plug.Response.call(@opts)
         |> Plug.Conn.send_resp(200, "{\"hello_world\":\"value\"}")
 
-      assert conn.resp_body == "{\"helloWorld\":\"value\"}"
+      assert conn.resp_body == "{\"HelloWorld\":\"value\"}"
     end
 
     test "skips conversion if no header is provided" do

--- a/test/accent/transformers/camel_case_test.exs
+++ b/test/accent/transformers/camel_case_test.exs
@@ -3,19 +3,19 @@ defmodule Accent.Transformer.CamelCaseTest do
 
   describe "call/2" do
     test "converts snake_case to CamelCase" do
-      assert Accent.Transformer.CamelCase.call("hello_world") == "HelloWorld"
+      assert Accent.Transformer.CamelCase.call("hello_world") == "helloWorld"
     end
 
     test "trims leading and trailing underscores from input" do
-      assert Accent.Transformer.CamelCase.call("_hello_world_") == "HelloWorld"
+      assert Accent.Transformer.CamelCase.call("_hello_world_") == "helloWorld"
     end
 
     test "supports atom as an input" do
-      assert Accent.Transformer.CamelCase.call(:hello_world) == :HelloWorld
+      assert Accent.Transformer.CamelCase.call(:hello_world) == :helloWorld
     end
 
     test "properly handles multiple consecutive underscores" do
-      assert Accent.Transformer.CamelCase.call("hello__world") == "HelloWorld"
+      assert Accent.Transformer.CamelCase.call("hello__world") == "helloWorld"
     end
   end
 end

--- a/test/accent/transformers/pascal_case_test.exs
+++ b/test/accent/transformers/pascal_case_test.exs
@@ -3,19 +3,19 @@ defmodule Accent.Transformer.PascalCaseTest do
 
   describe "call/2" do
     test "converts snake_case to camelCase" do
-      assert Accent.Transformer.PascalCase.call("hello_world") == "helloWorld"
+      assert Accent.Transformer.PascalCase.call("hello_world") == "HelloWorld"
     end
 
     test "trims leading and trailing underscores from input" do
-      assert Accent.Transformer.PascalCase.call("_hello_world_") == "helloWorld"
+      assert Accent.Transformer.PascalCase.call("_hello_world_") == "HelloWorld"
     end
 
     test "supports atom as an input" do
-      assert Accent.Transformer.PascalCase.call(:hello_world) == :helloWorld
+      assert Accent.Transformer.PascalCase.call(:hello_world) == :HelloWorld
     end
 
     test "properly handles multiple consecutive underscores" do
-      assert Accent.Transformer.PascalCase.call("hello__world") == "helloWorld"
+      assert Accent.Transformer.PascalCase.call("hello__world") == "HelloWorld"
     end
   end
 end


### PR DESCRIPTION
# Problem 
According to [this definition](http://wiki.c2.com/?PascalCase), the implementation thus far confused camelCase with PascalCase.

This is how it is supposed to be:

snake | camelCase | PascalCase 
 --- | --- | --- 
 test | test | Test 
 two_words | twoWords | TwoWords 

# Implementation
This PR exchanges the implementation of `Accent.Transformer.CamelCase` and `Accent.Transformer.PascalCase` with one another.

Tests and descriptions are updated.