### PR TITLE
Change response header to request header for content type

### DIFF
--- a/lib/accent/plugs/response.ex
+++ b/lib/accent/plugs/response.ex
@@ -66,16 +66,16 @@ defmodule Accent.Plug.Response do
   # private
 
   defp before_send_callback(conn, opts) do
-    response_content_type =
+    request_content_type =
       conn
-      |> get_resp_header("content-type")
+      |> get_req_header("content-type")
       |> Enum.at(0)
 
     # Note - we don't support "+json" content types, and probably shouldn't add
     # as a general feature because they may have specifications for the param
     # names - e.g. https://tools.ietf.org/html/rfc7265#page-6 that mean the
     # translation would be inappropriate
-    is_json_response = String.contains?(response_content_type || "", "application/json")
+    is_json_response = String.contains?(request_content_type || "", "application/json")
 
     if is_json_response do
       json_decoder = opts[:json_decoder]


### PR DESCRIPTION
I'll be making a PR for the #3, but the test `uses default case if specified` fails due to the `before_send_callback` uses `get_resp_header` instead of `get_req_header` for content-type.

With this change, I'll be able to proceed to fulfill the missing specs `uses default case if the specified case is not supported`.