### PR TITLE
Update case.ex

### DIFF
--- a/lib/accent/case.ex
+++ b/lib/accent/case.ex
@@ -22,10 +22,7 @@ defmodule Accent.Case do
       end
     end
   end
-
-  @doc """
-  Convert the keys of a list based on the provided transformer.
-  """
+  
   @spec convert(list, module) :: list
   def convert(list, transformer) when is_list(list) do
     for i <- list, into: [] do


### PR DESCRIPTION
Resolve warning

```
warning: redefining @doc attribute previously set at line 7.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head (the function signature not followed by any do-block). For example:

    @doc """
    new docs
    """
    def convert(...)

  lib/accent/case.ex:26: Accent.Case.convert/2
```